### PR TITLE
Enforce activity capacity on signup

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -105,6 +105,13 @@ def signup_for_activity(activity_name: str, email: str):
             detail="Student is already signed up"
         )
 
+    # Enforce capacity limit
+    if len(activity.get("participants", [])) >= activity.get("max_participants", 0):
+        raise HTTPException(
+            status_code=400,
+            detail="Activity is full"
+        )
+
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}


### PR DESCRIPTION
Add server-side check to prevent signups when participants >= max_participants. This implements issue #9.\n\nChanges:\n- src/app.py: raise 400 when activity is full in POST /activities/{name}/signup\n\nNotes:\n- This change enforces capacity server-side. Follow-up improvements (email normalization, UI disable) are tracked in separate issues.